### PR TITLE
Add `withDir` alias function, new `commentPrefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,31 @@ dumbcsv
 
 ## API
 
-### fromCSV(options: { data, file, separator = ',', headerFields, overrideExistingHeader, parseFloats = true }) : { toJSON: () => object, toMarkdown: () => string }
+### fromCSV(options: { data, file, separator = ',', headerFields, overrideExistingHeader, parseFloats = true, commentPrefix? }) : { toJSON: () => object, toMarkdown: () => string }
 Input `options` object:
 * `data` (string) -- a string representing the CSV data
 * OR `file` (string) -- a path to the CSV
 * `headerFields` (optional string[]) -- an array of strings containing the headers for the CSV, assuming they are not the 1st line
 * `overrideExistingHeader` (optional bool) -- if the 1st line IS a header, but your `headerFields` should override it
 * `parseFloats` (default true) -- if we should try and convert rows that are numbers into JS Number's, or if false keep everything as strings
+* `commentPrefix` (optional) -- Ignore all lines that start with this comment prefix.
 
 Output object :
 * `toJSON()` (function) -- calling this will return a javascript object that represents the CSV
 * `toMarkdown()` (function) -- calling this will return a string that has a formatted markdown table inside that represents the CSV
+
+### withDir(root: string): { openCSV(path: string, options?), openTSV(path: string, options?) }
+
+A simple way to open CSV/TSV/delimiter seperated files with respect to the `root` directory. Calling this function will return
+2 functions, openCSV and openTSV, both of which take a `path` that will be appended to the `root` path. The options these
+functions take are the same as `fromCSV`'s options, except that openTSV sets the seperator to '\t'. 
+Additionally, `fromTSV()`'s `toJSON()` method is called at the end for simplicity. If you need more configurability, use `fromCSV` directly.
+
+This is intended to return functions that can act similarly to the Node.js/CommonJS require() function. For example,
+
+```js
+const reader = require('dumb-csv').withDir(__dirname)
+const data = reader.openTSV('./data/data.tsv')
+```
+
+the above function will open './data/data.tsv' with respect to this file's current directory, with the seperator set as '\t'.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,25 @@
 module "dumb-csv" {
+  type Options = { data: string?, file?: string, separator: string, headerFields?: string[], overrideExistingHeader?: boolean, parseFloats?: boolean, commentPrefix?: boolean }
+
   // Input `options` object :
   // * `data` (string) -- a string representing the CSV data
   // * OR `file` (string) -- a path to the CSV
   // * `headerFields` (optional string[]) -- an array of strings containing the headers for the CSV, assuming they are not the 1st line
   // * `overrideExistingHeader` (optional bool) -- if the 1st line IS a header, but your `headerFields` should override it
   // * `parseFloats` (default true) -- if we should try and convert rows that are numbers into JS Number's, or if false keep everything as strings
+  // * `commentPrefix` (optional) -- Ignore all lines that start with this comment prefix.
   // 
   // Output object :
   // * `toJSON()` (function) -- calling this will return a javascript object that represents the CSV
   // * `toMarkdown()` (function) -- calling this will return a string that has a formatted markdown table inside that represents the CSV
-  function fromCSV(options: { data: string?, file?: string, separator: string, headerFields?: string[], overrideExistingHeader?: boolean, parseFloats?: boolean }) : { toJSON: () => object, toMarkdown: () => string }
+  function fromCSV(options: Options) : { toJSON: () => object, toMarkdown: () => string }
+
+  // A simple way to open CSV/TSV/delimiter seperated files wrt the `root` directory. All `openCSV` or `openTSV` calls will
+  // have the `root` prefixed to their file `path`. This is designed to return functions that act like CommonJS's require().
+  function withDir(root: string) : {
+    // Opens a TSV file at the `path` wrt the root, with the same options as `fromCSV` with the delimter set to '\t'
+    openTSV: (path: string, options?: Options) => object,
+    // Opens a CSV file at the `path` wrt the root, with the same options as `fromCSV`
+    openCSV: (path: string, options?: Options) => object
+  }
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -53,4 +53,8 @@ describe('basic', () => {
     console.log(json)
     assert.deepStrictEqual(json, [{ a: 'hello', b: 'world', c: '3.14159' }])
   })
+
+  it('withDir works', () => {
+    assert.deepStrictEqual(JSON.stringify(dumbcsv.withDir(__dirname).openTSV('file.tsv')), '[{"added":"1,2,3","removed":456},{"added":"hello\\tworld","removed":"a,b,c"}]')
+  })
 })

--- a/test/file.tsv
+++ b/test/file.tsv
@@ -1,0 +1,3 @@
+#added	removed
+1,2,3	456
+"hello	world"	a,b,c


### PR DESCRIPTION
This makes it about as seamless as using the require() function to load CSV/TSV files.